### PR TITLE
NIL type.

### DIFF
--- a/src/main/java/io/github/emanuelpalm/plisp/parser/Parser.java
+++ b/src/main/java/io/github/emanuelpalm/plisp/parser/Parser.java
@@ -53,7 +53,7 @@ public class Parser {
 
     private static Rule nil() {
         return (buffer) -> oneOf("NIL")
-                .transform(t -> SExpr.NUL)
+                .transform(t -> SExpr.NIL)
                 .apply(buffer);
     }
 

--- a/src/main/java/io/github/emanuelpalm/plisp/parser/Parser.java
+++ b/src/main/java/io/github/emanuelpalm/plisp/parser/Parser.java
@@ -5,6 +5,7 @@ import io.github.emanuelpalm.plisp.lexer.TokenClass;
 import io.github.emanuelpalm.plisp.runtime.SExpr;
 
 import static io.github.emanuelpalm.plisp.parser.Rule.*;
+import static io.github.emanuelpalm.plisp.parser.Rule.oneOf;
 
 /**
  * Parser.
@@ -12,7 +13,8 @@ import static io.github.emanuelpalm.plisp.parser.Rule.*;
  * Adheres to the following grammar:
  * <pre>
  * PROG -> EXPR _END | EXPR ERROR | ERROR
- * EXPR -> _ATM | CONS | LIST | QUOT
+ * EXPR -> NIL | _ATM | CONS | LIST | QUOT
+ * NIL  -> "NIL"
  * CONS -> "(" EXPR "." EXPR ")"
  * LIST -> "(" EXPR* ")"
  * QUOT -> "'" EXPR
@@ -45,7 +47,13 @@ public class Parser {
     }
 
     private static Rule expr() {
-        return (buffer) -> anyOf(oneOf(TokenClass.ATM), cons(), list(), quot())
+        return (buffer) -> anyOf(nil(), oneOf(TokenClass.ATM), cons(), list(), quot())
+                .apply(buffer);
+    }
+
+    private static Rule nil() {
+        return (buffer) -> oneOf("NIL")
+                .transform(t -> SExpr.NUL)
                 .apply(buffer);
     }
 

--- a/src/main/java/io/github/emanuelpalm/plisp/parser/Rule.java
+++ b/src/main/java/io/github/emanuelpalm/plisp/parser/Rule.java
@@ -46,6 +46,19 @@ public interface Rule {
         };
     }
 
+    /** Requires one {@link Token} with lexeme matching given string. */
+    static Rule oneOf(final String s) {
+        return (buffer) -> {
+            final int state = buffer.state();
+            final Token next = buffer.next();
+            if (next.lexeme().equals(s)) {
+                return Optional.of(new SExpr.Atom(next));
+            }
+            buffer.restore(state);
+            return Optional.empty();
+        };
+    }
+
     /** Requires any one of the given rules to succeed. */
     static Rule anyOf(final Rule... rs) {
         return (buffer) -> {

--- a/src/main/java/io/github/emanuelpalm/plisp/runtime/Evaluator.java
+++ b/src/main/java/io/github/emanuelpalm/plisp/runtime/Evaluator.java
@@ -10,7 +10,7 @@ public class Evaluator {
     public static final SExpr T = SExpr.Atom.of("t");
 
     /** Falsity, which also happens to be the empty list. */
-    public static final SExpr F = SExpr.NUL;
+    public static final SExpr F = SExpr.NIL;
 
     /**
      * Evaluates given expression e.
@@ -46,7 +46,7 @@ public class Evaluator {
      * @see <a href="http://www.paulgraham.com/rootsoflisp.html">The Roots of Lisp - Paul Graham, January 2002</a>
      */
     public static SExpr eval(final SExpr e) {
-        return eval(e, SExpr.NUL);
+        return eval(e, SExpr.NIL);
     }
 
     /**
@@ -116,7 +116,7 @@ public class Evaluator {
 
     /** Gets expression associated with atom e in environment a. */
     private static SExpr assoc(final SExpr e, final SExpr a) {
-        if (a instanceof SExpr.Nul) {
+        if (a instanceof SExpr.Nil) {
             throw new SExprException.AtomNotFound(e);
         }
         if (a.car().car().equals(e)) {
@@ -161,7 +161,7 @@ public class Evaluator {
 
     /** Evaluates some condition expression e using environment a. */
     private static SExpr cond(final SExpr e, final SExpr a) {
-        if (e.cdr() instanceof SExpr.Nul) {
+        if (e.cdr() instanceof SExpr.Nil) {
             throw new SExprException.CondExhausted(e);
         }
         if (eval(e.cdr().car().car(), a).equals(T)) {
@@ -190,7 +190,7 @@ public class Evaluator {
 
     /** Evaluates some list of expressions e using environment a. */
     private static SExpr evlis(final SExpr e, final SExpr a) {
-        if (e instanceof SExpr.Nul) {
+        if (e instanceof SExpr.Nil) {
             return e;
         }
         return new SExpr.Cons(eval(e.car(), a), evlis(e.cdr(), a));

--- a/src/main/java/io/github/emanuelpalm/plisp/runtime/SExpr.java
+++ b/src/main/java/io/github/emanuelpalm/plisp/runtime/SExpr.java
@@ -12,8 +12,8 @@ import java.util.Optional;
  * Symbolic expression.
  */
 public interface SExpr {
-    /** Global nul value. */
-    Nul NUL = new Nul();
+    /** Global nil value. */
+    Nil NIL = new Nil();
 
     /** Token representing s-expression origin, if expression originated from explicit code. */
     default Optional<Token> token() {
@@ -27,7 +27,7 @@ public interface SExpr {
 
     /** Contents of decrement register, if the current expression is a cons. */
     default SExpr cdr() {
-        return NUL;
+        return NIL;
     }
 
     /** Creates new cons list with given expression at the end. */
@@ -39,21 +39,21 @@ public interface SExpr {
      * Pairs up this expression's elements with that of given, if both are cons lists.
      * <p>
      * Will continue zipping as long as there are element in this cons list. If the given cons list would be shorter
-     * {@code Nul} values are used.
+     * {@code Nil} values are used.
      */
     default SExpr zip(final SExpr e) {
-        return NUL;
+        return NIL;
     }
 
     /**
-     * Nothing.
+     * An empty list.
      */
-    class Nul implements SExpr {
-        private Nul() {}
+    class Nil implements SExpr {
+        private Nil() {}
 
         @Override
         public String toString() {
-            return "NUL";
+            return "NIL";
         }
     }
 
@@ -96,7 +96,7 @@ public interface SExpr {
         public SExpr zip(final SExpr e) {
             return new Cons(
                     new Cons(this, e.car()),
-                    NUL
+                    NIL
             );
         }
 
@@ -133,7 +133,7 @@ public interface SExpr {
 
         /** Constructs cons list from given list of s-expressions. */
         public static SExpr of(final List<SExpr> es) {
-            SExpr e = NUL;
+            SExpr e = NIL;
             for (int i = es.size(); i-- != 0; ) {
                 e = new Cons(es.get(i), e);
             }

--- a/src/test/java/io/github/emanuelpalm/plisp/parser/TestParser.java
+++ b/src/test/java/io/github/emanuelpalm/plisp/parser/TestParser.java
@@ -21,7 +21,7 @@ public class TestParser {
                 new Object[]{"(x)", SExpr.Cons.of(SExpr.Atom.of("x"))},
                 new Object[]{"'x", SExpr.Cons.of(SExpr.Atom.of("quote"), SExpr.Atom.of("x"))},
                 new Object[]{"(a . b)", new SExpr.Cons(SExpr.Atom.of("a"), SExpr.Atom.of("b"))},
-                new Object[]{"(a . NIL)", new SExpr.Cons(SExpr.Atom.of("a"), SExpr.NUL)},
+                new Object[]{"(a . NIL)", new SExpr.Cons(SExpr.Atom.of("a"), SExpr.NIL)},
         };
     }
 

--- a/src/test/java/io/github/emanuelpalm/plisp/parser/TestParser.java
+++ b/src/test/java/io/github/emanuelpalm/plisp/parser/TestParser.java
@@ -21,6 +21,7 @@ public class TestParser {
                 new Object[]{"(x)", SExpr.Cons.of(SExpr.Atom.of("x"))},
                 new Object[]{"'x", SExpr.Cons.of(SExpr.Atom.of("quote"), SExpr.Atom.of("x"))},
                 new Object[]{"(a . b)", new SExpr.Cons(SExpr.Atom.of("a"), SExpr.Atom.of("b"))},
+                new Object[]{"(a . NIL)", new SExpr.Cons(SExpr.Atom.of("a"), SExpr.NUL)},
         };
     }
 

--- a/src/test/java/io/github/emanuelpalm/plisp/parser/TestRule.java
+++ b/src/test/java/io/github/emanuelpalm/plisp/parser/TestRule.java
@@ -81,6 +81,11 @@ public class TestRule {
                         Rule.anyOf(Rule.oneOf(TokenClass.ATM), Rule.oneOf(TokenClass.PAL)),
                         Optional.of(SExpr.Atom.of("x"))
                 },
+                new Object[]{
+                        lexerOf(new Token(TokenClass.ATM, "keyword")),
+                        Rule.anyOf(Rule.oneOf("keyword")),
+                        Optional.of(SExpr.Atom.of("keyword"))
+                },
         };
     }
 }

--- a/src/test/java/io/github/emanuelpalm/plisp/parser/TestRule.java
+++ b/src/test/java/io/github/emanuelpalm/plisp/parser/TestRule.java
@@ -54,7 +54,7 @@ public class TestRule {
                 new Object[]{
                         lexerOf(new Token(TokenClass.PAR, ")")),
                         Rule.manyOf(Rule.oneOf(TokenClass.ATM)),
-                        Optional.of(SExpr.NUL)
+                        Optional.of(SExpr.NIL)
                 },
                 new Object[]{
                         lexerOf(new Token(TokenClass.ATM, "x")),

--- a/src/test/java/io/github/emanuelpalm/plisp/runtime/TestSExpr.java
+++ b/src/test/java/io/github/emanuelpalm/plisp/runtime/TestSExpr.java
@@ -12,7 +12,7 @@ public class TestSExpr {
     public void shouldReturnSelfAndNulIfCallingCarAndCdrOnAtom() {
         final SExpr.Atom a = SExpr.Atom.of("test");
         assertEquals(a.car(), a);
-        assertEquals(a.cdr(), SExpr.NUL);
+        assertEquals(a.cdr(), SExpr.NIL);
     }
 
     @Test
@@ -28,7 +28,7 @@ public class TestSExpr {
         assertEquals(s, new SExpr.Cons(
                 SExpr.Atom.of("a"), new SExpr.Cons(
                 SExpr.Atom.of("b"), new SExpr.Cons(
-                SExpr.Atom.of("c"), SExpr.NUL))));
+                SExpr.Atom.of("c"), SExpr.NIL))));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class TestSExpr {
                 SExpr.Atom.of("d")
         ));
 
-        final SExpr c0b = new SExpr.Cons(SExpr.Atom.of("x"), SExpr.Atom.of("y")); // Not NUL-terminated.
+        final SExpr c0b = new SExpr.Cons(SExpr.Atom.of("x"), SExpr.Atom.of("y")); // Not NIL-terminated.
         assertEquals(c0b.concat(c1), SExpr.Cons.of(
                 SExpr.Atom.of("x"),
                 SExpr.Atom.of("y"),
@@ -62,7 +62,7 @@ public class TestSExpr {
                 new SExpr.Cons(SExpr.Atom.of("a1"), SExpr.Atom.of("b1"))
         ));
 
-        final SExpr c0b = new SExpr.Cons(SExpr.Atom.of("a0"), SExpr.Atom.of("a1")); // Not NUL-terminated.
+        final SExpr c0b = new SExpr.Cons(SExpr.Atom.of("a0"), SExpr.Atom.of("a1")); // Not NIL-terminated.
         assertEquals(c0b.zip(c1), SExpr.Cons.of(
                 new SExpr.Cons(SExpr.Atom.of("a0"), SExpr.Atom.of("b0")),
                 new SExpr.Cons(SExpr.Atom.of("a1"), SExpr.Atom.of("b1"))


### PR DESCRIPTION
As cons lists may be expressively defined using the `(a . b)` syntax, there should also be some way to define empty lists. This pull requests adds the `NIL` keyword which may be used for that very purpose.

The pull request makes `(x)` equal to `(x . NIL)`.
